### PR TITLE
[toc2mp3] Changed to remove control characters

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -15,6 +15,9 @@
 /* Define to 1 if you have the `getpagesize' function. */
 #undef HAVE_GETPAGESIZE
 
+/* Define if you have the iconv() function and it works. */
+#undef HAVE_ICONV
+
 /* Define to 1 if you have the `inet_aton' function. */
 #undef HAVE_INET_ATON
 
@@ -116,6 +119,9 @@
 
 /* Define to 1 if you have the `usleep' function. */
 #undef HAVE_USLEEP
+
+/* Define as const if the declaration of iconv() needs const. */
+#undef ICONV_CONST
 
 /* "Use real time scheduling for Linux" */
 #undef LINUX_QNX_SCHEDULING

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AM_CONFIG_HEADER(config.h)
 AM_MAINTAINER_MODE
 AC_CANONICAL_HOST
 AM_GCONF_SOURCE_2
+AM_ICONV
 
 AC_ARG_WITH(pcctsbin,[  --with-pcctsbin=dir     set directory of PCCTS parser generator executables],[pcctsbin=$withval],[pcctsbin=default])
 

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -13,7 +13,7 @@ toc2mp3_SOURCES = toc2mp3.cc
 
 toc2cddb_LDADD = $(top_builddir)/trackdb/libtrackdb.a
 toc2cue_LDADD = $(top_builddir)/trackdb/libtrackdb.a
-toc2mp3_LDADD = $(top_builddir)/trackdb/libtrackdb.a @LAME_LIBS@
+toc2mp3_LDADD = $(top_builddir)/trackdb/libtrackdb.a @LAME_LIBS@ @LIBICONV@
 
 if COND_MP3
 toc2cddb_LDADD += @MAD_LIBS@

--- a/utils/toc2mp3.cc
+++ b/utils/toc2mp3.cc
@@ -411,14 +411,12 @@ std::string &clean_string(std::string &s)
       s[i] = ' ';
       i++;
     }
-    else if (isalnum(c) || c == ' ' || c == '.' || c== '-' || c == '(' ||
-	     c == ')' || c == ')' || c == ',' || c == ':' || c == ';' ||
-	     c == '"' || c == '!' || c == '?' || c == '\'' || c == '$')  {
-      i++;
-    }
-    else {
+    else if (iscntrl(c) || c == '/') {
       s.erase(i, 1);
       len = s.length();
+    }
+    else {
+      i++;
     }
   }
 


### PR DESCRIPTION
Now it works well, but id3tag is not yet :'(
https://github.com/cdrdao/cdrdao/issues/6

```
$ cdrdao-1.2.4/utils/toc2mp3 b.toc
toc2mp3 version 1.2.4 - (C) Andreas Mueller <andreas@daneb.de>

Lame encoder settings:
LAME 3.100 64bits (http://lame.sf.net)
Using polyphase lowpass filter, transition band: 18671 Hz - 19205 Hz
Selected bit rate: 192 kbit/s

Starting encoding to target directory "."...
Encoding track 1 to "01_あいうえお_b.mp3"...

$ exiftool -Title -Artist -Album "01_あいうえお_b.mp3"
Title                           : ã‚ã„ã†ãˆãŠ
Album                           : b
```