### PR TITLE
fix the --swap argument so it works with the generic-mmc-raw driver as expected.

### DIFF
--- a/dao/dao.cc
+++ b/dao/dao.cc
@@ -532,7 +532,7 @@ static void *reader(void *args)
 
     if (cdr != NULL &&
 	((track->type() == TrackData::AUDIO && swap) ||
-	 (encodingMode == 0 && cdr->bigEndianSamples() == 0))) {
+	 (encodingMode == 0 && cdr->bigEndianSamples() == 0 && (track->type() != TrackData::AUDIO)))) {
       // swap audio data 
       long blockLen = cdr->blockSize(dataMode, subChanMode);
       char *brun = buf.buffer;


### PR DESCRIPTION
Alright, this was brutal to figure out.  Firstly, I want to apoligize about the previous pull requests on this topic that I should have tested more before submitting. This issue is so tedious that I didn't realize what the actual bug causing this was until just now with this current pull request, and the correct way to fix it.

My issue is, I wanted to use the cdrdao command below for 2 reasons:

cdrdao write --speed 1 --driver generic-mmc-raw --swap --eject *.cue

1) Some PSX games expect to read intentionally placed, incorrect EDC data at specific sector(s) as a from of additional copy protection. Most notably, the various Japanese Dance Dance Revolution games.

2) Various CD images and rips require the --swap argument to byteswap CD audio tracks in order for them to be burned correctly by CDRDAO, including this exact Dance Dance Revolution 2nd Remix PSX game rip. If you don't --swap, then you hear loud static noise instead of the expected CD audio when burning such an affected CD image.

Currently in CDRDAO, you can not use the --swap argument with the generic-mmc-raw driver correctly. The --swap argument fails to do what is told due to this statement: https://github.com/cdrdao/cdrdao/blob/cc3326bdaee6a16950483e08b3abc76c65871324/dao/dao.cc#L535 . 

Before I further explain, I think I should make something clear. The --swap argument is actually telling cdrdao to NOT swap on little endian systems. CDRDAO is swapping by default on a little endian system if you do not provide the --swap argument. If you provide the --swap argument on a little endian system for example, swap=1 will be turned into swap = 0. If you do not provide the argument on a little endian system, swap = 0 will be turned into swap = 1. Swapping is therefore done by default on little endian, and providing the --swap argument on little endian is actually disabling any byteswapping not enabling it!

The expected behavior occurs with the generic-mmc driver.  If the --swap argument is not specified in the arguments to cdrdao, swap = 0 gets flipped to swap = 1 (if it's required by a little endian system) and then the swap routine runs because the track is identified as an audio track and swap = 1; If the swap argument is provided, swap = 1 gets flipped into 0 and the routine is not run because neither statement is true in the if or statement. The file is an audio track, but swap = 0. And the other or part of the statement is not true as well under the generic-mmc driver so the swapping is correctly disabled.

The issue with the generic-mmc-raw driver is, the second part of the or if statement is always true. This is almost correct, because you actually need to swap any  data tracks that meet the second part of the or if statement when burning with the generic-mmc-raw driver (unlike the generic-mmc driver which does not need to do this when burning and does not make that statement true). The problem is, this will always swap audio tracks without fail. Rendering the --swap argument ineffective, making this bug. 

My fix is to only swap in the second part of the or if statement if the track is also not a CD audio file. Because of the first part of the or if statment, this is sufficent to ensure that the --swap argument works as expected on all drivers.

This was really complicated to figure out, as someone who had no idea how this was supposed to work and was unfamiliar with the code base. If you need me to be more clear on anything, please let me know. This does fix my own issue: https://github.com/cdrdao/cdrdao/issues/12




