### PR TITLE
Fix uninitialized TOC data file name

### DIFF
--- a/dao/main.cc
+++ b/dao/main.cc
@@ -219,6 +219,7 @@ DaoCommandLine::DaoCommandLine() :
     fullBurn(false), withCddb(false), taoSource(false), keepImage(false), overburn(false),
     writeSpeedControl(false), keep(false), printQuery(false), no_utf8(false)
 {
+    dataFilename = NULL;
     readingSpeed = -1;
     writingSpeed = -1;
     command = UNKNOWN;


### PR DESCRIPTION
This caused spurious garbled TOC files and/or segfaults when not using the `--datafile` option.