### PR TITLE
Fix error with short toc filename

### DIFF
--- a/trackdb/Toc.cc
+++ b/trackdb/Toc.cc
@@ -145,7 +145,7 @@ Toc *Toc::read(const string& filename)
         return NULL;
     }
 
-    if (filename.substr(filename.size() -4, 4) == ".cue")
+    if (filename.size() >= 4 && filename.substr(filename.size() - 4, 4) == ".cue")
         ret = parseCue(fp, filename.c_str());
     else
         ret = parseToc(fp, filename.c_str());


### PR DESCRIPTION
If the filename of the toc is shorter than 4 chars checking if the filename ends with ".cue" used to throw an error. We first need to check if the filename is at least 4 characters before we can take the substring of the last 4 chars to compare to ".cue".