### PR TITLE
Fix version command

### DIFF
--- a/dao/main.cc
+++ b/dao/main.cc
@@ -2489,8 +2489,10 @@ int main(int argc, char **argv)
     options.commitSettings(settings, settingsPath);
 
     // Just show version ? We're done.
-    if (options.command == SHOW_VERSION)
-	goto fail;
+    if (options.command == SHOW_VERSION) {
+        printVersion();
+        goto fail;
+    }
 
     errPrintParams.no_utf8 = options.no_utf8;
     filePrintParams.no_utf8 = options.no_utf8;


### PR DESCRIPTION
This is basically the minimal possible change to get version printing again. In my opinion, it should be in the same format as other commands, but the version command was already special before and I'm not familiar with the codebase or C++.
This closes #20.