### PR TITLE
Fix evaluation of result returned by Toc::write()

### DIFF
--- a/gcdmaster/CdDevice.cc
+++ b/gcdmaster/CdDevice.cc
@@ -393,7 +393,7 @@ bool CdDevice::recordDao(Gtk::Window& parent, TocEdit *tocEdit, int simulate,
   // Write out temporary toc file containing all the converted wav
   // files (don't want to rely on cdrdao doing the mp3->wav
   // translation, besides it's already been done).
-  if (!tocEdit->toc()->write(tocFileName, true)) {
+  if (tocEdit->toc()->write(tocFileName, true != 0)) {
     log_message(-2, _("Cannot write temporary toc-file."));
     return false;
   }


### PR DESCRIPTION
The change to Toc::write() that happened with cdrdao version 1.2.5 was not considered in CdDevice::recordDao(). This currently results in emitting the message "Cannot write temporary toc-file." and aborting the burning process, although the toc file has been written successfully.

This patch fixes the issue and enables one to burn CDs using gcdmaster again.

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1100713.