### PR TITLE
Fix build with GCC 15

### DIFF
--- a/pccts/antlr/gen.c
+++ b/pccts/antlr/gen.c
@@ -47,7 +47,7 @@ static set tokensRefdInBlock;
 					/* T r a n s l a t i o n  T a b l e s */
 
 /* C_Trans[node type] == pointer to function that knows how to translate that node. */
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 void (*C_Trans[NumNodeTypes+1])(...) = {
 	NULL,
 	NULL,					/* See next table.
@@ -70,7 +70,7 @@ Junctions have many types */
 /* C_JTrans[Junction type] == pointer to function that knows how to translate that
  * kind of junction node.
  */
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 void (*C_JTrans[NumJuncTypes+1])(...) = {
 	NULL,
 	(void (*)(...)) genSubBlk,

--- a/pccts/antlr/globals.c
+++ b/pccts/antlr/globals.c
@@ -190,7 +190,7 @@ char *CurAmbigbtype;
  * representing the FIRST sets for that node (maintains spatial info).
  * We use 'struct _tree' not 'tree' due to a g++ 2.4.3 bug.
  */
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 struct _tree *(*fpTraverse[NumNodeTypes+1])(... /* Node *, int, set * */) = {
 	NULL,
 	(struct _tree *(*)(...)) tJunc,
@@ -212,7 +212,7 @@ Tree *(*fpTraverse[NumNodeTypes+1])() = {
  * that node. (r stands for reach).  We use 'struct _set' not 'set'
  * due to a g++ 2.4.3 bug.
  */
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 struct _set (*fpReach[NumNodeTypes+1])(... /* Node *, int, set * */) = {
 	NULL,
 	(struct _set (*)(...)) rJunc,
@@ -231,7 +231,7 @@ set (*fpReach[NumNodeTypes+1])() = {
 #endif
 
 /* fpPrint[node type] == pointer to function that knows how to print that node. */
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 void (*fpPrint[NumNodeTypes+1])(... /* Node * */) = {
 	NULL,
 	(void (*)(...)) pJunc,
@@ -312,7 +312,7 @@ FILE	*output=NULL;		/* current parser output file */
 FILE	*input=NULL;		/* current grammar input file */
 char	*FileStr[MaxNumFiles];/* Ptr to array of file names on command-line */
 int		NumFiles=0;			/* current grammar file number */
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 void	(**fpTrans)(...),	/* array of ptrs to funcs that translate nodes */
 	 	(**fpJTrans)(...);	/*  ... that translate junctions */
 #else

--- a/pccts/antlr/main.c
+++ b/pccts/antlr/main.c
@@ -49,7 +49,7 @@ static int tnodes_used_in_guard_predicates_etc;     /* MR10 */
 typedef struct _Opt {
 			char *option;
 			int  arg;
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 			void (*process)(...);
 #else
 			void (*process)();
@@ -492,7 +492,7 @@ char *t;
 }
 
 Opt options[] = {
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
     { "-CC", 0, (void (*)(...)) pCC,	"Generate C++ output (default=FALSE)"},
     { "-ck", 1, (void (*)(...)) pCk,	"Set compressed lookahead depth; fast approximate lookahead"},
     { "-cr", 0, (void (*)(...)) pCr,	"Generate cross reference (default=FALSE)"},

--- a/pccts/antlr/proto.h
+++ b/pccts/antlr/proto.h
@@ -34,37 +34,37 @@ extern int tp;
 extern Junction *SynDiag;
 extern char Version[];
 extern char VersionDef[];
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 extern void (*fpPrint[])(...);
 #else
 extern void (*fpPrint[])();
 #endif
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 extern struct _set (*fpReach[])(...);
 #else
 extern struct _set (*fpReach[])();
 #endif
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 extern struct _tree *(*fpTraverse[])(...);
 #else
 extern struct _tree *(*fpTraverse[])();
 #endif
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 extern void (**fpTrans)(...);
 #else
 extern void (**fpTrans)();
 #endif
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 extern void (**fpJTrans)(...);
 #else
 extern void (**fpJTrans)();
 #endif
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 extern void (*C_Trans[NumNodeTypes+1])(...);
 #else
 extern void (*C_Trans[])();
 #endif
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 extern void (*C_JTrans[NumJuncTypes+1])(...);
 #else
 extern void (*C_JTrans[])();

--- a/pccts/dlg/main.c
+++ b/pccts/dlg/main.c
@@ -108,7 +108,7 @@ void p_warn_ambig()	{ warn_ambig = TRUE; }
 void p_cpp()		{ gen_cpp = TRUE; }
 #endif
 
-#ifdef __cplusplus
+#ifdef __USE_PROTOS
 typedef void (*WildFunc)(...);
 #else
 typedef void (*WildFunc)();


### PR DESCRIPTION
GCC 15 defaults to C23, in which the interpretation of function declarations without parameters changed from undefined (as in K&R) to  `void`.  The pccts code already has support for this via `__USE_PROTOS`, which is enabled in both standard C and C++.
