### PR TITLE
Remove obsolete automake macro AM_GCONF_SOURCE_2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AM_INIT_AUTOMAKE(subdir-objects)
 AC_CONFIG_HEADERS(config.h)
 AM_MAINTAINER_MODE
 AC_CANONICAL_HOST
-AM_GCONF_SOURCE_2
+#AM_GCONF_SOURCE_2
 AM_ICONV
 
 AC_ARG_WITH(pcctsbin,[  --with-pcctsbin=dir     set directory of PCCTS parser generator executables],[pcctsbin=$withval],[pcctsbin=default])


### PR DESCRIPTION
Automake issues: configure.ac:12: warning: macro 'AM_GCONF_SOURCE_2' not found in library
