### PR TITLE
Add /etc/default/cdrdao to the set of config files read

### DIFF
--- a/dao/main.cc
+++ b/dao/main.cc
@@ -2458,6 +2458,10 @@ int main(int argc, char **argv)
     if (settings->read(settingsPath) == 0)
 	log_message(3, "Read settings from \"%s\".", settingsPath);
 
+    settingsPath = "/etc/default/cdrdao";
+    if (settings->read(settingsPath) == 0)
+	log_message(3, "Read settings from \"%s\".", settingsPath);
+
     settingsPath = NULL;
 
     if ((homeDir = getenv("HOME")) != NULL) {


### PR DESCRIPTION
The man page also lists /etc/default/cdrdao as possible config file but main.cc does not try to load it without this patch.