### PR TITLE
Enhance and correct gcdmaster.desktop

### DIFF
--- a/gcdmaster/gcdmaster.desktop
+++ b/gcdmaster/gcdmaster.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Gnome CD Master
 Comment=Gnome Audio CD editor and burner
 Exec=gcdmaster %F
-Icon=gcdmaster.png
+Icon=gcdmaster
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=GNOME;AudioVideo;Application;X-Fedora;
+Categories=GTK;GNOME;Audio;AudioVideo;DiscBurning;
+Keywords=cdrom;cd;dvd;disc;burn;audio;


### PR DESCRIPTION
Drop deprecated key "Encoding".
Drop the extension from value "gcdmaster.png" for key "Icon".
Rework key "Categories" to list sensible categories from
 https://specifications.freedesktop.org/menu-spec/1.0/category-registry.html.
Add key "Keywords" with sensible value.