### PR TITLE
Fix typos and spelling errors in various files

### DIFF
--- a/dao/cdrdao.man
+++ b/dao/cdrdao.man
@@ -340,7 +340,8 @@ disks, e.g. to create a CD-EXTRA.
 .TP
 .BI \--overburn
 By default cdrdao will not allow one to write more data on a medium than
-specified by the current medium. This option allows to ignore this condition.
+specified by the current medium. This option allows one to ignore this
+condition.
 .TP
 .BI \--eject
 Eject the CD-R after writing or write simulation.
@@ -439,7 +440,7 @@ Upon exit from cdrdao, do not delete temporary WAV files created from MP3 and Og
 .TP
 .BI \--save
 Saves some of the current options to the settings file
-"$HOME/.cdrdao" and exit. See section \'SETTINGS\' for more details.
+"$HOME/.cdrdao" and exits. See section \'SETTINGS\' for more details.
 .TP
 .BI \-n
 Suppresses the 10 second pause before writing or simulating.

--- a/gcdmaster/CdTextDialog.cc
+++ b/gcdmaster/CdTextDialog.cc
@@ -56,7 +56,7 @@ CdTextDialog::CdTextDialog()
     page_[i].title = manage(new Gtk::Entry);
     page_[i].tabLabel = new Gtk::Label("");
     page_[i].performerButton =
-      new Gtk::CheckButton(_("Enable Perfomer Entries"));
+      new Gtk::CheckButton(_("Enable Performer Entries"));
     page_[i].performerButton->set_active(false);
     page_[i].performerButton->signal_toggled().
       connect(bind(mem_fun(*this, &CdTextDialog::activatePerformerAction), i));

--- a/gcdmaster/ProgressDialog.cc
+++ b/gcdmaster/ProgressDialog.cc
@@ -496,7 +496,7 @@ void ProgressDialog::update(unsigned long level)
     break;
 
   default:
-    statusMsg_->set_text(_("Unknow device action!"));
+    statusMsg_->set_text(_("Unknown device action!"));
     break;
   }
 }

--- a/gcdmaster/TocEdit.cc
+++ b/gcdmaster/TocEdit.cc
@@ -700,7 +700,7 @@ bool TocEdit::queueThread()
     if (result != 0) {
 
       if (result < 0)
-        signalError(_("An error occured while reading audio data"));
+        signalError(_("An error occurred while reading audio data"));
 
       else {
         // Post operating code here.

--- a/gcdmaster/gcdmaster.man
+++ b/gcdmaster/gcdmaster.man
@@ -393,7 +393,7 @@ CD-R/CD-RW in any case.
 
 .TP
 ISRC:
-Allows to edit the ISRC code of the track. The first fields
+Allows one to edit the ISRC code of the track. The first fields
 holds the country code; it will only accept capital letters. The
 second field holds the owner code, capital letters and digits are
 allowed. The remaining fields holds the year and a serial number and
@@ -401,7 +401,7 @@ will only accept digits. All fields must be filled to set the ISRC
 code and all fields must be cleared to remove it.
 
 .SS CD-TEXT Frame
-Allows to enter and edit the CD-TEXT data of each language number for
+Allows one to enter and edit the CD-TEXT data of each language number for
 this track. All fields are optional but at least "Title" and
 "Performer" should be filled.
 
@@ -451,7 +451,7 @@ The "Delete" button removes the selected device. The change takes
 immediate effect and all other changes will be lost.
 
 .SS Device Settings Frame
-This frame allows to edit the settings of the currently selected
+This frame allows one to edit the settings of the currently selected
 device.
 
 .TP


### PR DESCRIPTION
Fixes issues Debian's lint tool found in binaries
 I: gcdmaster: spelling-error-in-binary Perfomer Performer
    [usr/bin/gcdmaster]
 I: gcdmaster: spelling-error-in-binary Unknow Unknown
    [usr/bin/gcdmaster]
 I: gcdmaster: spelling-error-in-binary occured occurred
    [usr/bin/gcdmaster]
 I: cdrdao: typo-in-manual-page "allows to" "allows one to"
    [usr/share/man/man1/cdrdao.1.gz:343]
 I: gcdmaster: typo-in-manual-page "Allows to" "Allows one to"
    [usr/share/man/man1/gcdmaster.1.gz:396]
 I: gcdmaster: typo-in-manual-page "Allows to" "Allows one to"
    [usr/share/man/man1/gcdmaster.1.gz:404]
 I: gcdmaster: typo-in-manual-page "allows to" "allows one to"
    [usr/share/man/man1/gcdmaster.1.gz:454]
plus one grammatical error in the cdrdao manual page source "exist" "exists".
    [dao/cdrdao.man:443]