### PR TITLE
Restore null terminators in CD-TEXT strings

### DIFF
--- a/trackdb/CdTextItem.cc
+++ b/trackdb/CdTextItem.cc
@@ -52,10 +52,11 @@ void CdTextItem::setRawText(const u8* buffer, size_t buffer_len)
 
 void CdTextItem::setRawText(const std::string& str)
 {
-    data_.resize(str.size());
+    data_.resize(str.size() + 1);
     auto writer = data_.begin();
     for (const auto c : str)
         *writer++ = c;
+    *writer++ = '\0';
     dataType_ = DataType::SBCC;
     updateEncoding();
 }


### PR DESCRIPTION
`std::string` is logically not null-terminated, but CD-TEXT strings are. Explicitly add null-termination when setting a `CdTextItem` from a `std::string` to make the resulting CD-TEXT correct.

Fixes #18.

I've done only minimal testing of this (checking if `simulate -v 4` produces the same hexdump as on 1.2.4 for one particular TOC file that happens not to contain any non-ASCII characters). Please point out problems/suggest improvements!