### PR TITLE
Init ao_sample_format

### DIFF
--- a/gcdmaster/SoundIF-ao.cc
+++ b/gcdmaster/SoundIF-ao.cc
@@ -17,6 +17,7 @@
  *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include <string.h>
 #include <ao/ao.h>
 
 #include "SoundIF.h"
@@ -37,6 +38,7 @@ SoundIF::SoundIF()
 
   impl_ = new SoundIFImpl;
   impl_->driverId = ao_default_driver_id();
+  memset(&impl_->format, 0, sizeof(impl_->format));
   impl_->format.bits = 16;
   impl_->format.rate = 44100;
   impl_->format.channels = 2;

--- a/trackdb/FormatMp3.cc
+++ b/trackdb/FormatMp3.cc
@@ -111,7 +111,7 @@ FormatSupport::Status FormatMp3::madInit()
 
   // Initialize libao for WAV output;
   ao_sample_format out_format;
-  bzero(&out_format, sizeof(out_format));
+  memset(&out_format, 0, sizeof(out_format));
   out_format.bits = 16;
   out_format.rate = 44100;
   out_format.channels = 2;

--- a/trackdb/FormatOgg.cc
+++ b/trackdb/FormatOgg.cc
@@ -84,6 +84,7 @@ FormatSupport::Status FormatOgg::oggInit()
       return FS_WRONG_FORMAT;
   }
 
+  memset(&outFormat_, 0, sizeof(outFormat_));
   outFormat_.bits = 16;
   outFormat_.rate = 44100;
   outFormat_.channels = 2;


### PR DESCRIPTION
Init `ao_sample_format` via `memset(0)`, for `ao_sample_format` could have additional fields like `matrix`:
```
typedef struct ao_sample_format {
	int  bits; /* bits per sample */
	int  rate; /* samples per second (in a single channel) */
	int  channels; /* number of audio channels */
	int  byte_format; /* Byte ordering in sample, see constants below */
        char *matrix; /* input channel location/ordering */
} ao_sample_format;
```

This PR will also make vendor patches, where i found this, obsolete, like https://cdn.netbsd.org/pub/pkgsrc/pkgsrc-2025Q3/pkgsrc/sysutils/cdrdao/patches/patch-au