### PR TITLE
Fix code checking for the Lame library by removing pre posix workaround

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -50,9 +50,7 @@ main ()
   char *tmp_version;
   lame_version_t lame_version;
 
-  /* HP/UX 0 (%@#!) writes to sscanf strings */
-  tmp_version = strdup("$1");
-  if (sscanf(tmp_version, "%d.%d", &major, &minor) != 2) {
+  if (sscanf("$1", "%d.%d", &major, &minor) != 2) {
      printf("%s, bad version string\n", "$1");
      exit(1);
   }


### PR DESCRIPTION
Fix https://github.com/cdrdao/cdrdao/issues/60

Before:
```
$CXXFLAGS="-fsanitize=address" ./configure
[...]
checking for Lame library version >= 3.100... no
[...]
  Building toc2mp3   : no
```

After:
```
$ CXXFLAGS="-fsanitize=address" ./configure
[...]
checking for Lame library version >= 3.100... yes
[...]
  Building toc2mp3   : yes
```