### PR TITLE
Fix install prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,12 @@ AC_ARG_WITH(ogg-support,[  --with-ogg-support      enable OGG format support (de
 
 AC_ARG_WITH(mp3-support,[  --with-mp3-support      enable MP3 format support (default is YES)],[],[with_mp3_support=yes])
 
+if test "$prefix" = "NONE"; then
+  AC_DEFINE(PREFIX, [], [prefix])
+else
+  AC_DEFINE_UNQUOTED(PREFIX, ["$prefix"], [prefix])
+fi
+
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX

--- a/dao/main.cc
+++ b/dao/main.cc
@@ -2382,15 +2382,15 @@ int main(int argc, char **argv)
 
     Settings* settings = new Settings;
 
-    settingsPath = "/etc/cdrdao.conf";
+    settingsPath = PREFIX "/etc/cdrdao.conf";
     if (settings->read(settingsPath) == 0)
 	log_message(3, "Read settings from \"%s\".", settingsPath);
 
-    settingsPath = "/etc/defaults/cdrdao";
+    settingsPath = PREFIX "/etc/defaults/cdrdao";
     if (settings->read(settingsPath) == 0)
 	log_message(3, "Read settings from \"%s\".", settingsPath);
 
-    settingsPath = "/etc/default/cdrdao";
+    settingsPath = PREFIX "/etc/default/cdrdao";
     if (settings->read(settingsPath) == 0)
 	log_message(3, "Read settings from \"%s\".", settingsPath);
 


### PR DESCRIPTION
Before:
```
./configure --prefix=/home/michael/opt/cdrdao-20251226
[...]
strace /home/michael/opt/cdrdao-20251226/bin/cdrdao 2>&1 |grep "/etc"
[...]
openat(AT_FDCWD, "/etc/cdrdao.conf", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/etc/defaults/cdrdao", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/etc/default/cdrdao", O_RDONLY) = -1 ENOENT (No such file or directory)
```

After:
```
./configure --prefix=/home/michael/opt/cdrdao-20251226
[...]
strace /home/michael/opt/cdrdao-20251226/bin/cdrdao 2>&1 |grep "/etc"
[...]
openat(AT_FDCWD, "/home/michael/opt/cdrdao-20251226/etc/cdrdao.conf", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/home/michael/opt/cdrdao-20251226/etc/defaults/cdrdao", O_RDONLY) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/home/michael/opt/cdrdao-20251226/etc/default/cdrdao", O_RDONLY) = -1 ENOENT (No such file or directory)
```