### PR TITLE
Replace deprecated bcopy(3) and bzero(3)

### DIFF
--- a/dao/ScsiIf-freebsd-cam.cc
+++ b/dao/ScsiIf-freebsd-cam.cc
@@ -118,8 +118,8 @@ int ScsiIf::sendCmd(const unsigned char *cmd, int cmdLen, const unsigned char *d
     u_int8_t *data_ptr = NULL;
     size_t data_len = 0;
 
-    bzero(impl_->ccb, sizeof(union ccb));
-    bcopy(cmd, &impl_->ccb->csio.cdb_io.cdb_bytes, cmdLen);
+    memset(impl_->ccb, 0, sizeof(union ccb));
+    memmove(&impl_->ccb->csio.cdb_io.cdb_bytes, cmd, cmdLen);
 
     if (dataOut && dataOutLen > 0) {
         data_ptr = (u_int8_t *)dataOut;
@@ -168,8 +168,8 @@ int ScsiIf::inquiry()
     int i;
     struct scsi_inquiry_data inq_data;
 
-    bzero(impl_->ccb, sizeof(union ccb));
-    bzero(&inq_data, sizeof(inq_data));
+    memset(impl_->ccb, 0, sizeof(union ccb));
+    memset(&inq_data, 0, sizeof(inq_data));
 
     scsi_inquiry(&impl_->ccb->csio, DEF_RETRY_COUNT, NULL, MSG_SIMPLE_Q_TAG, (u_int8_t *)&inq_data,
                  sizeof(inq_data), 0, 0, SSD_FULL_SIZE, impl_->timeout);


### PR DESCRIPTION
The bcopy(3) and bzero(3) methods have been long deprecated on FreeBSD and DragonFly. Replace with memmove(3) and memset(3), respectively.